### PR TITLE
Update src/MarkPad/ViewModel/SettingsViewModel.cs

### DIFF
--- a/src/MarkPad/ViewModel/SettingsViewModel.cs
+++ b/src/MarkPad/ViewModel/SettingsViewModel.cs
@@ -75,7 +75,7 @@ namespace MarkPad.ViewModel
         {
             get
             {
-                return (bool)_localSettings.Values["Distraction"];
+                return _distraction;
             }
             set
             {


### PR DESCRIPTION
I assume Distraction should return the field to make it consistent with the other properties?
